### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,6 +2,9 @@ name: Python application
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/UMEBOSHIISAN/example-pip-githubactions/security/code-scanning/1](https://github.com/UMEBOSHIISAN/example-pip-githubactions/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the minimal required permission is `contents: read`, as the workflow interacts with the repository's contents (e.g., checking out code). No write permissions are necessary for the current functionality.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
